### PR TITLE
Fix the URL of the logo link to the website's root

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="padder">
       <div class="navbar animated slideInDown">
-        <div class="logo"><a href="/"><img src="{{.Site.Params.logoImage | relURL}}" alt="{{.Site.Params.logoImageAlt}}"></a></div>
+        <div class="logo"><a href="{{.Site.BaseURL}}"><img src="{{.Site.Params.logoImage | relURL}}" alt="{{.Site.Params.logoImageAlt}}"></a></div>
         <div class="burger-wrap">
           <div class="burger">
             <div class="top"></div>


### PR DESCRIPTION
The link to the website's root was using '/', which may be working in the majority of cases (i.e. 50+%) but will surely be breaking a considerable number of installs. This commit fixes that.

Fixes #4 